### PR TITLE
Sharp image lose orientation

### DIFF
--- a/src/img-shrink.ts
+++ b/src/img-shrink.ts
@@ -20,10 +20,10 @@ async function HandleImgShrinkFromUrl(req: Request, res: Response) {
     const imageBufferResized = await resizeImageBuffer(imageBuffer, +widthmax);
     console.log("img-shrink: converting done");
     res.status(200);
-    res.contentType('image/jpeg');
-    res.removeHeader('Access-Control-Allow-Headers')
-    res.setHeader('Accept-Ranges', 'bytes');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+    res.contentType("image/jpeg");
+    res.removeHeader("Access-Control-Allow-Headers");
+    res.setHeader("Accept-Ranges", "bytes");
+    res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
     res.send(imageBufferResized);
   } catch (e) {
     console.error("img-shrink: An Error occurred when processing img", {
@@ -40,6 +40,7 @@ async function resizeImageBuffer(
 ): Promise<Buffer> {
   const data = await sharp(imgBuffer)
     .resize({ width: widthmax, withoutEnlargement: false })
+    .withMetadata()
     .jpeg()
     .toBuffer();
   return data;

--- a/src/img-shrink.ts
+++ b/src/img-shrink.ts
@@ -20,10 +20,10 @@ async function HandleImgShrinkFromUrl(req: Request, res: Response) {
     const imageBufferResized = await resizeImageBuffer(imageBuffer, +widthmax);
     console.log("img-shrink: converting done");
     res.status(200);
-    res.contentType("image/jpeg");
-    res.removeHeader("Access-Control-Allow-Headers");
-    res.setHeader("Accept-Ranges", "bytes");
-    res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+    res.contentType('image/jpeg');
+    res.removeHeader('Access-Control-Allow-Headers')
+    res.setHeader('Accept-Ranges', 'bytes');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
     res.send(imageBufferResized);
   } catch (e) {
     console.error("img-shrink: An Error occurred when processing img", {


### PR DESCRIPTION
Hi Ben,
We came with an issue when resizing image.
Original image here: https://firebasestorage.googleapis.com/v0/b/comm-unstable-fmlink/o/buildings%2F7Vs4BC4sfPFtbJPUyGCY%2Finspection_events%2Fg8vjOoqJ0dNiTWBwwIg2%2Finspector-2020-07-09T19%3A14%3A41.590087?alt=media&token=1809d41c-2fc9-43ff-96f4-d3ec14794692

After resize: https://pdf1test-guvpqljtmq-an.a.run.app/img/urlshrink/?url=https%3A%2F%2Ffirebasestorage.googleapis.com%2Fv0%2Fb%2Fcomm-unstable-fmlink%2Fo%2Fbuildings%252F7Vs4BC4sfPFtbJPUyGCY%252Finspection_events%252Fg8vjOoqJ0dNiTWBwwIg2%252Finspector-2020-07-09T19%253A14%253A41.590087%3Falt%3Dmedia%26token%3D1809d41c-2fc9-43ff-96f4-d3ec14794692&widthmax=600;

The image will lose its original orientation. I found a solution from here: https://stackoverflow.com/questions/48716266/sharp-image-library-rotates-image-when-resizing.

Hope this make sense to you.

Thanks
Wyatt
